### PR TITLE
Make sdk browser friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,20 @@
   "name": "hyperliquid",
   "version": "1.5.2",
   "description": "SDK for Hyperliquid API",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": ["src", "dist"],
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
     "build:watch": "tsc --watch",
     "clean": "rimraf dist",
     "prepare": "npm run build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,9 @@ export class Hyperliquid {
   public ws: WebSocketClient;
   public subscriptions: WebSocketSubscriptions;
   public custom: CustomOperations;
+  public symbolConversion: SymbolConversion;
 
   private rateLimiter: RateLimiter;
-  private symbolConversion: SymbolConversion;
   private isValidPrivateKey: boolean = false;
   private walletAddress: string | null = null;
   private _initialized: boolean = false;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
- Recent changes broke web compatibility

Added `tsup` to builds
- Generates both ESM and CommonJS builds automatically
- Improves package compatibility across different environments (Node.js, browsers, bundlers)
- Reduces bundle size through tree-shaking and optimizations

Made `symbolConversion`public, so browsers can initialize for asset renaming. Currently `initialize` on index can only be called by servers because of its websocket dependency. 
