### PR TITLE
added support for modify user evm

### DIFF
--- a/examples/exchange_api_testing.cjs
+++ b/examples/exchange_api_testing.cjs
@@ -248,6 +248,13 @@ async function testExchangeAPI() {
   });
   console.log(approveBuilderFeeResponse);
 
+  await waitForUserInput("Press Enter to continue to Modify User EVM...");
+
+  // 19. Modify User EVM
+  console.log("\n19. Modify User EVM:");
+  const modifyUserEvmResponse = await sdk.exchange.modifyUserEvm(true);
+  console.log(modifyUserEvmResponse);
+
   await waitForUserInput("Press Enter to continue to Deposit to Staking...");
 }
 

--- a/src/rest/exchange.ts
+++ b/src/rest/exchange.ts
@@ -410,6 +410,20 @@ export class ExchangeAPI {
     }
   }
 
+  async modifyUserEvm(usingBigBlocks: boolean): Promise<any> {
+    await this.parent.ensureInitialized();
+    try {
+      const action = { type: ExchangeType.EVM_USER_MODIFY, usingBigBlocks };
+      const nonce = Date.now();
+      const signature = await signL1Action(this.wallet, action, null, nonce, this.IS_MAINNET);
+
+      const payload = { action, nonce, signature };
+      return this.httpApi.makeRequest(payload, 1);
+    } catch (error) {
+      throw error;
+    }
+  }
+
   async placeTwapOrder(orderRequest: TwapOrder): Promise<TwapOrderResponse> {
         await this.parent.ensureInitialized();
         try {

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -68,7 +68,8 @@ export enum ExchangeType {
     TWAP_ORDER = 'twapOrder',
     TWAP_CANCEL = 'twapCancel',
     APPROVE_AGENT = 'approveAgent',
-    APPROVE_BUILDER_FEE = 'approveBuilderFee'
+    APPROVE_BUILDER_FEE = 'approveBuilderFee',
+    EVM_USER_MODIFY = 'evmUserModify'
 }
 
 export const WEBSOCKET = {


### PR DESCRIPTION
due to today's hyper evm update, it's now necessary to submit an L1 action to start submitting tx in big blocks (which is required to deploy most contracts) [(here's the announcement + changelog in hl's discord)](https://discord.com/channels/1029781241702129716/1208476333089497189/1334521323082223678).

this pr adds its support - to be used as: `await sdk.exchange.modifyUserEvm(usingBigBlocks)`