### PR TITLE
align callback data param type with message.data

### DIFF
--- a/src/websocket/subscriptions.ts
+++ b/src/websocket/subscriptions.ts
@@ -189,7 +189,7 @@ export class WebSocketSubscriptions {
   async subscribeToCandle(
     coin: string,
     interval: string,
-    callback: (data: Candle[] & { coin: string; interval: string }) => void
+    callback: (data: Candle) => void
   ): Promise<void> {
     const convertedCoin = await this.symbolConversion.convertSymbol(coin, 'reverse');
     const subscriptionKey = this.getSubscriptionKey('candle', { coin: convertedCoin, interval });


### PR DESCRIPTION
This PR aligns `subscribeToCandle` `callback` `data` argument type with what is returned in `message.data` from Hyperliquid.