### PR TITLE
fix: correct data types for converted members in Candle type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -270,18 +270,7 @@ export interface L2Book {
   ];
 }
 
-export type CandleSnapshot = {
-  T: number;
-  c: string;
-  h: string;
-  i: string;
-  l: string;
-  n: number;
-  o: string;
-  s: string;
-  t: number;
-  v: string;
-}[];
+export type CandleSnapshot = Candle[];
 
 export type AssetCtx = {
   dayBaseVlm: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -443,14 +443,12 @@ export interface Candle {
   T: number; // close time
   s: string; // symbol
   i: string; // interval
-  o: string; // open
-  c: string; // close
-  h: string; // high
-  l: string; // low
-  v: string; // volume
+  o: number; // open
+  c: number; // close
+  h: number; // high
+  l: number; // low
+  v: number; // volume
   n: number; // number of trades
-  coin: string;
-  interval: string;
 }
 
 export interface WsUserFill {


### PR DESCRIPTION
PR to update the member types of Candle type.  I missed the fact that you had already converted numeric strings to number types in my previous PR.

![Received Candle object](https://github.com/user-attachments/assets/70ced6d5-787f-44c4-9932-c8d6b3418c07)
