### PR TITLE
Add support for nSigFigs and mantissa in getL2Book

### DIFF
--- a/src/rest/info.ts
+++ b/src/rest/info.ts
@@ -125,9 +125,9 @@ export class InfoAPI {
     return this.generalAPI.getOrderStatus(user, oid, rawResponse);
   }
 
-  async getL2Book(coin: string, rawResponse: boolean = false): Promise<L2Book> {
+  async getL2Book(coin: string, rawResponse: boolean = false, nSigFigs: number = 5, mantissa: number = undefined): Promise<L2Book> {
     await this.parent.ensureInitialized();
-    return this.generalAPI.getL2Book(coin, rawResponse);
+    return this.generalAPI.getL2Book(coin, rawResponse, nSigFigs, mantissa);
   }
 
   async getCandleSnapshot(

--- a/src/rest/info/general.ts
+++ b/src/rest/info/general.ts
@@ -126,10 +126,12 @@ export class GeneralInfoAPI {
     return rawResponse ? response : await this.symbolConversion.convertResponse(response);
   }
 
-  async getL2Book(coin: string, rawResponse: boolean = false): Promise<L2Book> {
+  async getL2Book(coin: string, rawResponse: boolean = false, nSigFigs: number = 5, mantissa: number= undefined): Promise<L2Book> {
     const response = await this.httpApi.makeRequest({
       type: InfoType.L2_BOOK,
       coin: await this.symbolConversion.convertSymbol(coin, 'reverse'),
+      nSigFigs,
+      mantissa
     });
     return rawResponse ? response : await this.symbolConversion.convertResponse(response);
   }


### PR DESCRIPTION
Currently, getL2Book does not support all the arguments for getL2Book. This pull request adds support for `nSigFigs` and `mantissa` as per the official Hyperliquid documentation.