### PR TITLE
chore: 🤖 add .idea to ignore IntelliJ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ src/**/*.js
 .vscode/
 /dist
 *.env
+.DS_Store
+.idea


### PR DESCRIPTION
Added .idea directory to .gitignore to prevent RustRover IDEA's configuration files (e.g., workspace settings, run configurations) from being committed. This ensures a cleaner repository and avoids conflicts between developers using different IDE settings.